### PR TITLE
Fix hanging php tests

### DIFF
--- a/php/src/OfficeCleaner1/OfficeCleaner1.php
+++ b/php/src/OfficeCleaner1/OfficeCleaner1.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace OfficeCleaner1;
+
+if (PHP_SAPI === 'cli') { Program::main(STDIN); }
+?>

--- a/php/src/OfficeCleaner1/OfficeCleaner1.php
+++ b/php/src/OfficeCleaner1/OfficeCleaner1.php
@@ -2,5 +2,8 @@
 
 namespace OfficeCleaner1;
 
-if (PHP_SAPI === 'cli') { Program::main(STDIN); }
+if (PHP_SAPI === 'cli') { 
+  require_once __DIR__ . '/../../vendor/autoload.php';
+  Program::main(STDIN);
+}
 ?>

--- a/php/src/OfficeCleaner1/Program.php
+++ b/php/src/OfficeCleaner1/Program.php
@@ -26,6 +26,4 @@ class Program
         echo "=> Cleaned: " . $mainRobot->getVisitedPositions();
     }
 }
-
-if (PHP_SAPI === 'cli') { Program::main(STDIN); }
 ?>

--- a/php/tests/OfficeCleanerTest.php
+++ b/php/tests/OfficeCleanerTest.php
@@ -15,7 +15,7 @@ class OfficeCleanerTest extends TestCase {
             $stdin = fopen($filePath, 'r');
 
             ob_start();
-            $sut($filePath);
+            $sut($stdin);
             $output = ob_get_clean();
 
             static::assertSame($expected, trim($output));


### PR DESCRIPTION
This should fix the issue of the hanging php tests.
I don't know any other way of creating an "entrypoint" to Program::main that is not called in an PHPUnit environment, so I added the extra OfficeCleaner1.php file that just contains the call to Program::main(STDIN).